### PR TITLE
Fix Error in Mac Address creation script

### DIFF
--- a/random-mac.sh
+++ b/random-mac.sh
@@ -2,4 +2,4 @@
 #MAC ADDRESS RANDOMIZER
 #http://www.commandlinefu.com/commands/view/8471/generat-a-random-mac-address
 
-(date; cat /proc/interrupts) | md5sum | sed -r 's/^(.{10}).*$/\1/; s/([0-9a-f]{2})/\1:/g; s/:$//;'
+(date; cat /proc/interrupts) | md5sum | sed -r 's/^(.{12}).*$/\1/; s/([0-9a-f]{2})/\1:/g; s/:$//;'


### PR DESCRIPTION
Randommac.sh was was generating a 10 character address, but Virt-Manager wouldn't accept the mac addresses generated until I changed the script to 12. 
